### PR TITLE
Create routing to handle webhooks

### DIFF
--- a/app/assets/stylesheets/transactions.scss
+++ b/app/assets/stylesheets/transactions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Transactions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,0 +1,6 @@
+class TransactionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:default_webhook]
+  def default_webhook
+    render status: :ok, json: @controller.to_json
+  end
+end

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -1,0 +1,2 @@
+module TransactionsHelper
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
+  resources :transactions, only: [:index] do
+    post 'default_webhook', :on => :collection
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class TransactionsControllerTest < ActionDispatch::IntegrationTest
+  describe 'when a POST request is received at the webhook URL' do
+    it 'should return a 200 OK response' do
+      post default_webhook_transactions_url
+      assert_response :ok
+    end
+  end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -2,6 +2,3 @@
 
 one:
   name: MyString
-
-two:
-  name: MyString

--- a/test/fixtures/providers.yml
+++ b/test/fixtures/providers.yml
@@ -2,6 +2,3 @@
 
 one:
   name: MyString
-
-two:
-  name: MyString

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,15 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'minitest/autorun'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  # parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  extend MiniTest::Spec::DSL
 end


### PR DESCRIPTION
## What does this PR change?

- Add a Transactions controller with a default action to handle webhooks from different providers.
**Why?**
The rationale is that transaction webhooks from different providers are expected to be largely similar in structure, and so the responsibility for distinguishing between them could reside at a lower level (inside the controller action or in a separate service).
- Switch on forgery protection in test environment.
**Why?**
This is to enable testing if the webhook URL can be accessed by a third party without an authenticity token.